### PR TITLE
Make links in warning/danger boxes colorful in light theme

### DIFF
--- a/lib/client/styles/vars.scss
+++ b/lib/client/styles/vars.scss
@@ -32,13 +32,13 @@
   --c-warning: #e7c000;
   --c-warning-bg: #fffae3;
   --c-warning-title: #ad9000;
-  --c-warning-text: #746000;
-  --c-warning-text-accent: var(--c-text);
+  --c-warning-text: var(--c-text);
+  --c-warning-text-accent: #b89a06;
   --c-danger: #cc0000;
   --c-danger-bg: #ffe0e0;
   --c-danger-title: #990000;
-  --c-danger-text: #660000;
-  --c-danger-text-accent: var(--c-text);
+  --c-danger-text: var(--c-text);
+  --c-danger-text-accent: #cc4949;
   --c-details-bg: #eeeeee;
 
   // badge component colors


### PR DESCRIPTION
Makes the links in warning and danger boxes colored and the non-link text black in light theme. This both better matches dark theme and the light theme tip boxes and also just looks better imo as it has better contrast and the links are more distinct.

Before:
![スクリーンショット 2021-10-27 17 14 47](https://user-images.githubusercontent.com/41608708/139157552-db55af00-e3a5-48fa-8031-5cd8c5707e54.png)
![スクリーンショット 2021-10-27 17 14 57](https://user-images.githubusercontent.com/41608708/139157554-61dee0cf-dd06-4211-a0a0-9a08a8d95dc9.png)

After:
![スクリーンショット 2021-10-27 17 11 58](https://user-images.githubusercontent.com/41608708/139157550-4a04c22e-b83b-4390-989c-e094944667f3.png)
![スクリーンショット 2021-10-27 17 14 32](https://user-images.githubusercontent.com/41608708/139157551-668f92a1-e532-4f2b-abd9-afe2e1f2d06c.png)
