### PR TITLE
Fix invalid HTML in sidebar

### DIFF
--- a/lib/client/components/Sidebar.vue
+++ b/lib/client/components/Sidebar.vue
@@ -5,11 +5,9 @@
     <slot name="top" />
 
     <ul class="sidebar-links">
-      <SidebarChild
-        v-for="item in sidebarItems"
-        :key="item.link || item.text"
-        :item="item"
-      />
+      <li v-for="item in sidebarItems" :key="item.link || item.text">
+        <SidebarChild :item="item" />
+      </li>
     </ul>
 
     <slot name="bottom" />


### PR DESCRIPTION
Fixes the sidebar's `<ul>` not having `<li>` inside it, which is [invalid](https://validator.w3.org/nu/?showsource=yes&doc=https%3A%2F%2Fdsi.cfw.guide%2Flaunching-the-exploit).